### PR TITLE
Set up basic Discord bot with ping command

### DIFF
--- a/src/bot.ts
+++ b/src/bot.ts
@@ -1,0 +1,49 @@
+import { Client, GatewayIntentBits, Collection, REST, Routes } from 'discord.js';
+import { readdirSync } from 'fs';
+import path from 'path';
+import config from './config';
+import type { Command } from './types';
+
+const client = new Client({ intents: [GatewayIntentBits.Guilds] });
+const commands = new Collection<string, Command>();
+
+async function loadCommands(): Promise<void> {
+  const commandsPath = path.join(__dirname, 'commands');
+  const files = readdirSync(commandsPath).filter(f => f.endsWith('.ts') || f.endsWith('.js'));
+  const commandData = [];
+
+  for (const file of files) {
+    const filePath = path.join(commandsPath, file);
+    const command: Command = (await import(filePath)) as Command;
+    commands.set(command.data.name, command);
+    commandData.push(command.data.toJSON());
+  }
+
+  const rest = new REST({ version: '10' }).setToken(config.discordToken);
+  await rest.put(Routes.applicationCommands(config.clientId), { body: commandData });
+}
+
+async function loadEvents(): Promise<void> {
+  const eventsPath = path.join(__dirname, 'events');
+  const files = readdirSync(eventsPath).filter(f => f.endsWith('.ts') || f.endsWith('.js'));
+
+  for (const file of files) {
+    const filePath = path.join(eventsPath, file);
+    const event = await import(filePath);
+    if (event.once) {
+      client.once(event.name, (...args) => event.execute(...args, commands));
+    } else {
+      client.on(event.name, (...args) => event.execute(...args, commands));
+    }
+  }
+}
+
+async function main(): Promise<void> {
+  await loadCommands();
+  await loadEvents();
+  await client.login(config.discordToken);
+}
+
+main().catch(error => {
+  console.error('Failed to start bot:', error);
+});

--- a/src/commands/ping.ts
+++ b/src/commands/ping.ts
@@ -1,0 +1,9 @@
+import { SlashCommandBuilder, ChatInputCommandInteraction } from 'discord.js';
+
+export const data = new SlashCommandBuilder()
+  .setName('ping')
+  .setDescription('Replies with Pong!');
+
+export async function execute(interaction: ChatInputCommandInteraction): Promise<void> {
+  await interaction.reply('Pong!');
+}

--- a/src/events/interactionCreate.ts
+++ b/src/events/interactionCreate.ts
@@ -1,0 +1,26 @@
+import { Interaction, Collection } from 'discord.js';
+import type { Command } from '../types';
+
+export const name = 'interactionCreate';
+
+export async function execute(
+  interaction: Interaction,
+  commands: Collection<string, Command>
+): Promise<void> {
+  if (!interaction.isChatInputCommand()) return;
+
+  const command = commands.get(interaction.commandName);
+  if (!command) return;
+
+  try {
+    await command.execute(interaction);
+  } catch (error) {
+    console.error(error);
+    const reply = { content: 'There was an error executing this command!', ephemeral: true } as const;
+    if (interaction.replied || interaction.deferred) {
+      await interaction.followUp(reply);
+    } else {
+      await interaction.reply(reply);
+    }
+  }
+}

--- a/src/events/ready.ts
+++ b/src/events/ready.ts
@@ -1,0 +1,8 @@
+import { Client } from 'discord.js';
+
+export const name = 'ready';
+export const once = true;
+
+export function execute(client: Client): void {
+  console.log(`Logged in as ${client.user?.tag}!`);
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,6 @@
+import { SlashCommandBuilder, ChatInputCommandInteraction } from 'discord.js';
+
+export interface Command {
+  data: SlashCommandBuilder;
+  execute: (interaction: ChatInputCommandInteraction) => Promise<void>;
+}


### PR DESCRIPTION
## Summary
- add Discord bot entry point that dynamically loads commands and events
- register slash commands and login with DISCORD_TOKEN
- include sample ping command and core event handlers

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_b_689911c5dc948331b57982159750fa61