### PR TITLE
feat: sync perks with role updates

### DIFF
--- a/src/bot.ts
+++ b/src/bot.ts
@@ -3,6 +3,7 @@ import { readdirSync } from 'fs';
 import path from 'path';
 import config from './config';
 import type { Command } from './types';
+import { setupRoleSync } from './watchers/roleSync';
 
 const client = new Client({ intents: [GatewayIntentBits.Guilds] });
 const commands = new Collection<string, Command>();
@@ -41,6 +42,7 @@ async function loadEvents(): Promise<void> {
 async function main(): Promise<void> {
   await loadCommands();
   await loadEvents();
+  await setupRoleSync(client);
   await client.login(config.discordToken);
 }
 

--- a/src/watchers/roleSync.ts
+++ b/src/watchers/roleSync.ts
@@ -1,0 +1,88 @@
+import { Client, GuildMember } from 'discord.js';
+import fs from 'fs/promises';
+import path from 'path';
+
+// Mapping of Discord role IDs to perk identifiers.
+// Update the role IDs to match your server configuration.
+const ROLE_PERKS: Record<string, string> = {
+  '123456789012345678': 'supporter',
+  '234567890123456789': 'vip',
+};
+
+const GRACE_PERIOD_MS = 72 * 60 * 60 * 1000; // 72 hours
+const STORE_PATH = path.join(__dirname, '../../data/entitlements.json');
+
+interface PerkInfo {
+  grantedAt: number;
+  expiresAt?: number;
+}
+
+// userId -> perk -> info
+type EntitlementStore = Record<string, Record<string, PerkInfo>>;
+
+async function readStore(): Promise<EntitlementStore> {
+  try {
+    const data = await fs.readFile(STORE_PATH, 'utf8');
+    return JSON.parse(data) as EntitlementStore;
+  } catch {
+    return {};
+  }
+}
+
+async function writeStore(store: EntitlementStore): Promise<void> {
+  await fs.mkdir(path.dirname(STORE_PATH), { recursive: true });
+  await fs.writeFile(STORE_PATH, JSON.stringify(store, null, 2), 'utf8');
+}
+
+/**
+ * Setup synchronization between Discord roles and in-game perks.
+ * A 72 hour grace period is applied before perks are revoked.
+ */
+export async function setupRoleSync(client: Client): Promise<void> {
+  const entitlements = await readStore();
+
+  client.on('guildMemberUpdate', async (oldMember: GuildMember, newMember: GuildMember) => {
+    const now = Date.now();
+    const userId = newMember.id;
+    const userEntitlements = entitlements[userId] ?? {};
+
+    // Remove expired entitlements
+    for (const [perk, info] of Object.entries(userEntitlements)) {
+      if (info.expiresAt && info.expiresAt <= now) {
+        delete userEntitlements[perk];
+      }
+    }
+
+    const oldRoles = new Set(oldMember.roles.cache.keys());
+    const newRoles = new Set(newMember.roles.cache.keys());
+
+    // Roles added -> grant perks immediately
+    for (const roleId of newRoles) {
+      if (!oldRoles.has(roleId)) {
+        const perk = ROLE_PERKS[roleId];
+        if (perk) {
+          userEntitlements[perk] = { grantedAt: now };
+        }
+      }
+    }
+
+    // Roles removed -> schedule perk revocation after grace period
+    for (const roleId of oldRoles) {
+      if (!newRoles.has(roleId)) {
+        const perk = ROLE_PERKS[roleId];
+        if (perk && userEntitlements[perk]) {
+          userEntitlements[perk].expiresAt = now + GRACE_PERIOD_MS;
+        }
+      }
+    }
+
+    if (Object.keys(userEntitlements).length > 0) {
+      entitlements[userId] = userEntitlements;
+    } else {
+      delete entitlements[userId];
+    }
+
+    await writeStore(entitlements);
+  });
+}
+


### PR DESCRIPTION
## Summary
- add watcher that syncs perks with member role changes and persists entitlements
- wire watcher into bot startup

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npx tsc -p tsconfig.json --noEmit` *(fails: top-level export not allowed in CommonJS modules)*

------
https://chatgpt.com/codex/tasks/task_b_689916bd2744833188162f9e28964cf5